### PR TITLE
Decoding failure when trying to derive from the incorrect type

### DIFF
--- a/src/main/scala/io/github/patceev/binance/models/Depth.scala
+++ b/src/main/scala/io/github/patceev/binance/models/Depth.scala
@@ -5,7 +5,7 @@ import io.circe.{Decoder, HCursor}
 import io.github.patceev.binance.models.Depth.{Ask, Bid}
 
 case class Depth(
-  lastUpdateId: Int,
+  lastUpdateId: Long,
   bids: List[Bid],
   asks: List[Ask]
 )
@@ -24,6 +24,6 @@ object Depth {
 
   object Ask {
     implicit val decode: Decoder[Ask] = (c: HCursor) =>
-      c.as[(Double, Double)].map(bid => Ask(bid._1, bid._2))
+      c.as[(Double, Double)].map(ask => Ask(ask._1, ask._2))
   }
 }

--- a/src/test/scala/RestGeneralSpec.scala
+++ b/src/test/scala/RestGeneralSpec.scala
@@ -28,7 +28,7 @@ class RestGeneralSpec extends AsyncFlatSpec {
 	}
 
 	it should "return depth for 100 by default" in {
-		generalApi.depth("ETHBTC").map(depth => {
+		generalApi.depth("BTCUSDT").map(depth => {
 			assert(depth.asks.length === depth.bids.length)
 			assert(depth.asks.length === 100)
 		})


### PR DESCRIPTION
In case of `BTCUSDT` pair which has a relatively long history of data, `lastUpdateId` could be more than the size of `Int`.

Here's the error log
```
[Decoding Error] message: DecodingFailure(Int, List(DownField(lastUpdateId)))
```

